### PR TITLE
Fix base page text input handling

### DIFF
--- a/main/ui/base_page.py
+++ b/main/ui/base_page.py
@@ -54,3 +54,4 @@ class BasePage:
             logger.info(f"Текст в инпут {locator} введен")
         except (TimeoutException, NoSuchElementException):
             logger.error(f"Не удалось добавить текст в инпут {locator}", exc_info=True)
+            raise


### PR DESCRIPTION
## Summary
- ensure `BasePage.type` re-raises exceptions when element input fails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_6842f92104f883319b1d780d11b8de17